### PR TITLE
Use full class name when raising errors

### DIFF
--- a/lib/dhl/bcs/v2/shipment.rb
+++ b/lib/dhl/bcs/v2/shipment.rb
@@ -43,18 +43,18 @@ module Dhl::Bcs::V2
     end
 
     def product=(product)
-      raise Error, "No valid product code #{product}. Please use one of these: #{PRODUCTS.join(', ')}" unless PRODUCTS.include?(product)
+      raise Dhl::Bcs::Error, "No valid product code #{product}. Please use one of these: #{PRODUCTS.join(', ')}" unless PRODUCTS.include?(product)
       @product = product
     end
 
     def to_soap_hash(ekp, participation_number)
-      raise Error, 'Packing weight in kilo must be set!' unless weight
-      raise Error, 'Sender address must be set!' unless shipper
-      raise Error, 'Receiver address must be set!' unless receiver
-      raise Error, 'Product must be set!' unless product
+      raise Dhl::Bcs::Error, 'Packing weight in kilo must be set!' unless weight
+      raise Dhl::Bcs::Error, 'Sender address must be set!' unless shipper
+      raise Dhl::Bcs::Error, 'Receiver address must be set!' unless receiver
+      raise Dhl::Bcs::Error, 'Product must be set!' unless product
 
       account_number = "#{ekp}#{PRODUCT_PROCEDURE_NUMBERS[product]}#{participation_number}"
-      raise Error, 'Need a 14 character long account number. Check EKP and participation_number' if account_number.size != 14
+      raise Dhl::Bcs::Error, 'Need a 14 character long account number. Check EKP and participation_number' if account_number.size != 14
       {
         'ShipmentDetails' => {}.tap { |h|
           h['product'] = product

--- a/test/dhl/bcs/v2/client_test.rb
+++ b/test/dhl/bcs/v2/client_test.rb
@@ -81,6 +81,36 @@ module Dhl::Bcs::V2
       end
     end
 
+    def test_create_shipment_without_weight
+      shipment = Dhl::Bcs.build_shipment(
+        shipper: {
+          name: 'Christoph Wagner',
+          company: 'webit! Gesellschaft für neue Medien mbH',
+          street_name: 'Schandauer Straße',
+          street_number: '34',
+          zip: '01309',
+          city: 'Dresden',
+          country_code: 'DE',
+          email: 'wagner@webit.de'
+        },
+        receiver: {
+          name: 'John Doe',
+          street_name: 'Mainstreet',
+          street_number: '10',
+          address_addition: 'Appartment 2a',
+          zip: '90210',
+          city: 'Springfield',
+          country_code: 'DE',
+          email: 'john.doe@example.com'
+        },
+        shipment_date: Date.new(2016, 7, 13)
+      )
+
+      assert_raises Dhl::Bcs::Error do
+        result = @client.validate_shipment(shipment)
+      end
+    end
+
     def test_create_shipment_order_request
       #WebMock.allow_net_connect!
       stub_and_check(file_prefix: 'create_shipment_order') do


### PR DESCRIPTION
Let me first thank you for this awesome gem! It works like a charm. :+1: 

There is just a few small bugs when the caller missed a mandatory argument and the gem wants to raise an exception a `NameError` is raised:

`NameError: uninitialized constant Dhl::Bcs::V2::Shipment::Error`

This PR fixes it.