### PR TITLE
Print only if codeable

### DIFF
--- a/lib/dhl/bcs/v2/client.rb
+++ b/lib/dhl/bcs/v2/client.rb
@@ -102,16 +102,18 @@ module Dhl::Bcs::V2
 
     protected
 
-    def build_shipment_orders(shipments, label_response_type: 'URL')
+    def build_shipment_orders(shipments, label_response_type: 'URL', print_only_if_codeable: false)
       raise Dhl::Bcs::DataError, 'No more than 30 shipments allowed per request!' if shipments.size > 30
       {
         'ShipmentOrder' =>
           shipments.map.with_index(1) do |shipment, index|
-            {
+            h = {
               'sequenceNumber' => format('%02i', index.to_s),
               'Shipment' => shipment.to_soap_hash(@ekp, @participation_number),
-              'LabelResponseType' => label_response_type.to_s.upcase
+              'LabelResponseType' => label_response_type.to_s.upcase,
             }
+            h['PrintOnlyIfCodeable/'] = {'@active': 1} if print_only_if_codeable
+            h
           end
       }
     end

--- a/test/stubs/create_shipment_codeable_error_request.xml
+++ b/test/stubs/create_shipment_codeable_error_request.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bcs="http://dhl.de/webservices/businesscustomershipping" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:cis="http://dhl.de/webservice/cisbase">
+  <env:Header>
+    <cis:Authentification>
+      <cis:user>2222222222_01</cis:user>
+      <cis:signature>pass</cis:signature>
+      <cis:type>0</cis:type>
+    </cis:Authentification>
+  </env:Header>
+  <env:Body>
+    <bcs:CreateShipmentOrderRequest>
+      <bcs:Version>
+        <majorRelease>2</majorRelease>
+        <minorRelease>0</minorRelease>
+      </bcs:Version>
+      <ShipmentOrder>
+        <sequenceNumber>01</sequenceNumber>
+        <Shipment>
+          <ShipmentDetails>
+            <product>V01PAK</product>
+            <shipmentDate>2016-07-13</shipmentDate>
+            <cis:accountNumber>22222222220101</cis:accountNumber>
+            <ShipmentItem>
+              <weightInKG>3.5</weightInKG>
+            </ShipmentItem>
+          </ShipmentDetails>
+          <Shipper>
+            <Name>
+              <cis:name1>Christoph Wagner</cis:name1>
+              <cis:name2>webit! Gesellschaft für neue Medien mbH</cis:name2>
+            </Name>
+            <Address>
+              <cis:streetName>Schandauer Straße</cis:streetName>
+              <cis:streetNumber>34</cis:streetNumber>
+              <cis:zip>01309</cis:zip>
+              <cis:city>Dresden</cis:city>
+              <cis:Origin>
+                <cis:countryISOCode>DE</cis:countryISOCode>
+              </cis:Origin>
+            </Address>
+            <Communication>
+              <cis:email>wagner@webit.de</cis:email>
+            </Communication>
+          </Shipper>
+          <Receiver>
+            <cis:name1>John Doe</cis:name1>
+            <Communication>
+              <cis:email>john.doe@example.com</cis:email>
+            </Communication>
+            <Address>
+              <cis:streetName>Mainstreet</cis:streetName>
+              <cis:streetNumber>10</cis:streetNumber>
+              <cis:addressAddition>Appartment 2a</cis:addressAddition>
+              <cis:zip>90210</cis:zip>
+              <cis:city>Springfield</cis:city>
+              <cis:Origin>
+                <cis:countryISOCode>DE</cis:countryISOCode>
+              </cis:Origin>
+            </Address>
+          </Receiver>
+        </Shipment>
+        <LabelResponseType>URL</LabelResponseType>
+        <PrintOnlyIfCodeable active="1"/>
+      </ShipmentOrder>
+    </bcs:CreateShipmentOrderRequest>
+  </env:Body>
+</env:Envelope>

--- a/test/stubs/create_shipment_codeable_error_response.xml
+++ b/test/stubs/create_shipment_codeable_error_response.xml
@@ -1,0 +1,28 @@
+<soap:Envelope xmlns:bcs="http://dhl.de/webservices/businesscustomershipping" xmlns:cis="http://dhl.de/webservice/cisbase" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Header xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"/>
+  <soap:Body>
+    <bcs:CreateShipmentOrderResponse>
+      <bcs:Version>
+        <majorRelease xmlns="">2</majorRelease>
+        <minorRelease xmlns="">0</minorRelease>
+      </bcs:Version>
+      <Status xmlns="">
+        <statusCode>1101</statusCode>
+        <statusText>Hard validation error occured.</statusText>
+        <statusMessage>In der Sendung trat mindestens ein harter Fehler auf.</statusMessage>
+      </Status>
+      <CreationState xmlns="">
+        <sequenceNumber>01</sequenceNumber>
+        <LabelData>
+          <Status>
+            <statusCode>1101</statusCode>
+            <statusText>Hard validation error occured.</statusText>
+            <statusMessage>In der Sendung trat mindestens ein harter Fehler auf.</statusMessage>
+            <statusMessage>Die Postleitzahl konnte nicht gefunden werden.</statusMessage>
+            <statusMessage>Der eingegebene Wert ist zu lang und wurde gekürzt.</statusMessage>
+          </Status>
+        </LabelData>
+      </CreationState>
+    </bcs:CreateShipmentOrderResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/test/stubs/create_shipment_print_only_if_codeable_request.xml
+++ b/test/stubs/create_shipment_print_only_if_codeable_request.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bcs="http://dhl.de/webservices/businesscustomershipping" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:cis="http://dhl.de/webservice/cisbase">
+  <env:Header>
+    <cis:Authentification>
+      <cis:user>2222222222_01</cis:user>
+      <cis:signature>pass</cis:signature>
+      <cis:type>0</cis:type>
+    </cis:Authentification>
+  </env:Header>
+  <env:Body>
+    <bcs:CreateShipmentOrderRequest>
+      <bcs:Version>
+        <majorRelease>2</majorRelease>
+        <minorRelease>0</minorRelease>
+      </bcs:Version>
+      <ShipmentOrder>
+        <sequenceNumber>01</sequenceNumber>
+        <Shipment>
+          <ShipmentDetails>
+            <product>V01PAK</product>
+            <shipmentDate>2016-07-13</shipmentDate>
+            <cis:accountNumber>22222222220101</cis:accountNumber>
+            <ShipmentItem>
+              <weightInKG>3.5</weightInKG>
+            </ShipmentItem>
+          </ShipmentDetails>
+          <Shipper>
+            <Name>
+              <cis:name1>Christoph Wagner</cis:name1>
+              <cis:name2>webit!</cis:name2>
+            </Name>
+            <Address>
+              <cis:streetName>Schandauer Straße</cis:streetName>
+              <cis:streetNumber>34</cis:streetNumber>
+              <cis:zip>01309</cis:zip>
+              <cis:city>Dresden</cis:city>
+              <cis:Origin>
+                <cis:countryISOCode>DE</cis:countryISOCode>
+              </cis:Origin>
+            </Address>
+            <Communication>
+              <cis:email>wagner@webit.de</cis:email>
+            </Communication>
+          </Shipper>
+          <Receiver>
+            <cis:name1>Jane Doe</cis:name1>
+            <Communication>
+              <cis:email>jane.doe@example.com</cis:email>
+            </Communication>
+            <Address>
+              <cis:streetName>Willy-Brandt-Straße</cis:streetName>
+              <cis:streetNumber>1</cis:streetNumber>
+              <cis:zip>10557</cis:zip>
+              <cis:city>Berlin</cis:city>
+              <cis:Origin>
+                <cis:countryISOCode>DE</cis:countryISOCode>
+              </cis:Origin>
+            </Address>
+          </Receiver>
+        </Shipment>
+        <LabelResponseType>URL</LabelResponseType>
+        <PrintOnlyIfCodeable active="1"/>
+      </ShipmentOrder>
+    </bcs:CreateShipmentOrderRequest>
+  </env:Body>
+</env:Envelope>

--- a/test/stubs/create_shipment_print_only_if_codeable_response.xml
+++ b/test/stubs/create_shipment_print_only_if_codeable_response.xml
@@ -1,0 +1,28 @@
+<soap:Envelope xmlns:bcs="http://dhl.de/webservices/businesscustomershipping" xmlns:cis="http://dhl.de/webservice/cisbase" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Header xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"/>
+  <soap:Body>
+    <bcs:CreateShipmentOrderResponse>
+      <bcs:Version>
+        <majorRelease xmlns="">2</majorRelease>
+        <minorRelease xmlns="">0</minorRelease>
+      </bcs:Version>
+      <Status xmlns="">
+        <statusCode>0</statusCode>
+        <statusText>ok</statusText>
+        <statusMessage>Der Webservice wurde ohne Fehler ausgeführt.</statusMessage>
+      </Status>
+      <CreationState xmlns="">
+        <sequenceNumber>01</sequenceNumber>
+        <LabelData>
+          <Status>
+            <statusCode>0</statusCode>
+            <statusText>ok</statusText>
+            <statusMessage>Der Webservice wurde ohne Fehler ausgeführt.</statusMessage>
+          </Status>
+          <cis:shipmentNumber>22222222201019582121</cis:shipmentNumber>
+          <labelUrl>https://cig.dhl.de/gkvlabel/SANDBOX/dhl-vls/gw/shpmntws/printShipment?token=JD7HKktuvugIFEkhSvCfbEz4J8Ah0dkcVuw4PzBGRyRnW%2FwEPAwfytLtb31e7gMDsSX32%2BEB5exp8nNPs%2FhJSQ%3D%3D</labelUrl>
+        </LabelData>
+      </CreationState>
+    </bcs:CreateShipmentOrderResponse>
+  </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
I added an argument to build_shipment_orders which sets <PrintOnlyIfCodeable active="1" /> in each ShipmentOrder, if true. When set, most weak validation errors become hard ones, disallowing label creation with incorrect postal codes for example. 

One might replicate this function with validate_shipment before creating an actual label, but PrintOnlyIfCodeable has the perk of only marking some validation errors as hard. E.g. a too long company name stays weak, wrong street becomes hard.

Could you review the changes? 
Fine gem, thanks!